### PR TITLE
Fix pyflakes plugin for Python3-only Vim

### DIFF
--- a/vim/bundle/pyflakes-vim/ftplugin/python/pyflakes.vim
+++ b/vim/bundle/pyflakes-vim/ftplugin/python/pyflakes.vim
@@ -24,17 +24,20 @@ endif
 if !exists("b:did_python_init")
     let b:did_python_init = 0
 
-    if !has('python')
-        echoerr "Error: the pyflakes.vim plugin requires Vim to be compiled with +python"
+    if has('python3')
+        let s:pycmd = 'python3'
+    elseif has('python')
+        let s:pycmd = 'python'
+    else
+        echoerr "Error: the pyflakes.vim plugin requires Vim to be compiled with +python or +python3"
         finish
     endif
 
-if !exists('g:pyflakes_use_quickfix')
-    let g:pyflakes_use_quickfix = 1
-endif
+    if !exists('g:pyflakes_use_quickfix')
+        let g:pyflakes_use_quickfix = 1
+    endif
 
-
-    python << EOF
+    execute s:pycmd . ' << EOF'
 import vim
 import os.path
 import sys
@@ -232,7 +235,7 @@ if !exists("*s:RunPyflakes")
         let b:qf_list = []
         let b:qf_window_count = -1
         
-        python << EOF
+        execute s:pycmd . ' << EOF'
 for w in check(vim.current.buffer):
     vim.command('let s:matchDict = {}')
     vim.command("let s:matchDict['lineNum'] = " + str(w.lineno))


### PR DESCRIPTION
## Summary
- adapt pyflakes.vim to work with Python3

## Testing
- `vim -Nu NONE -es -c 'set runtimepath+=vim/bundle/pyflakes-vim | filetype plugin on | e tempfile.py | q'`


------
https://chatgpt.com/codex/tasks/task_e_68925bdf0ea483338a44890d94a03741